### PR TITLE
fix: Make update scripts executable in spec file

### DIFF
--- a/ublue-updater.spec
+++ b/ublue-updater.spec
@@ -44,10 +44,10 @@ sudo install -m 0755 update-ublue %{buildroot}%{_bindir}/update-ublue
 %attr(0644,root,root) %{_exec_prefix}/lib/systemd/user/%{NAME}.timer
 %attr(0755,root,root) %{_exec_prefix}/lib/systemd/user-preset/00-ublue-updater-preset
 %attr(0755,root,root) %{_exec_prefix}/etc/ublue-updater/ublue-updater.conf
-%attr(0644,root,root) %{_sysconfdir}/update.d/00-system-update.sh
-%attr(0644,root,root) %{_sysconfdir}/update.d/01-flatpak-system-update.sh
-%attr(0644,root,root) %{_sysconfdir}/update.d/02-flatpak-user-update.sh
-%attr(0644,root,root) %{_sysconfdir}/update.d/03-distrobox-user-update.sh
+%attr(0755,root,root) %{_sysconfdir}/update.d/00-system-update.sh
+%attr(0755,root,root) %{_sysconfdir}/update.d/01-flatpak-system-update.sh
+%attr(0755,root,root) %{_sysconfdir}/update.d/02-flatpak-user-update.sh
+%attr(0755,root,root) %{_sysconfdir}/update.d/03-distrobox-user-update.sh
 
 %exclude %{_datadir}/%{VENDOR}/*
 


### PR DESCRIPTION
Changes permissions from 0644 to 0755 on all update scripts